### PR TITLE
Draft: CFG Row Click Modal

### DIFF
--- a/src/components/CompanyModal.tsx
+++ b/src/components/CompanyModal.tsx
@@ -29,7 +29,7 @@ export function CompanyModal({ opened, onClose, company }: CompanyModalProps) {
             <Modal.Title>
                 <Group style={{ backgroundColor: "var(--mantine-color-green-0)" }} h={rem(100)} w="100%" p="md" justify="space-around">
                     <Title order={3}>{company.name}</Title>
-                    <SeverityChip severity={company.severity} isMobile={false} />
+                    <SeverityChip severity={company.severity} />
                 </Group>
                 <Divider mx="md" color="var(--mantine-color-green-8)" />
             </Modal.Title>
@@ -48,6 +48,7 @@ export function CompanyModal({ opened, onClose, company }: CompanyModalProps) {
                             style={{
                                 backgroundColor: "var(--mantine-color-white)",
                                 border: "calc(0.0625rem* var(--mantine-scale)) solid var(--mantine-color-gray-4)",
+                                borderRadius: rem(4),
                                 padding: `${rem(5.5)} ${rem(12)}`,
                                 overflowY: "auto",
                             }}

--- a/src/components/CompanyModal.tsx
+++ b/src/components/CompanyModal.tsx
@@ -1,0 +1,68 @@
+import { Anchor, Divider, Group, Modal, rem, Stack, Textarea, Title } from "@mantine/core";
+import { Company } from "src/types";
+import { SeverityChip } from "./SeverityChip";
+
+export type CompanyModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    company: Company;
+};
+
+function SourceLink({ link, index }: { link: string; index: number }) {
+    return (
+        <Anchor href={link} target="_blank" c="var(--mantine-color-green-8)">
+            [{index}:] {link}
+        </Anchor>
+    );
+}
+
+export function CompanyModal({ opened, onClose, company }: CompanyModalProps) {
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            style={{ backgroundColor: "var(--mantine-color-green-0)" }}
+            size="xl"
+            withCloseButton={false}
+            centered
+        >
+            <Modal.Title>
+                <Group style={{ backgroundColor: "var(--mantine-color-green-0)" }} h={rem(100)} w="100%" p="md" justify="space-around">
+                    <Title order={3}>{company.name}</Title>
+                    <SeverityChip severity={company.severity} isMobile={false} />
+                </Group>
+                <Divider mx="md" color="var(--mantine-color-green-8)" />
+            </Modal.Title>
+            <Modal.Body style={{ backgroundColor: "var(--mantine-color-green-0)", rowGap: "2rem", overflowY: "auto" }} pt="md">
+                <Stack>
+                    <Group w="100%" justify="space-between">
+                        <Title order={4}>Notes:</Title>
+                        <Textarea readOnly value={company.notes ?? "None"} flex={10} autosize maxRows={10} maw="75%" />
+                    </Group>
+                    <Group w="100%" justify="space-between">
+                        <Title order={4}>Sources:</Title>
+                        <Stack
+                            flex={10}
+                            maw="75%"
+                            mah={rem(200)}
+                            style={{
+                                backgroundColor: "var(--mantine-color-white)",
+                                border: "calc(0.0625rem* var(--mantine-scale)) solid var(--mantine-color-gray-4)",
+                                padding: `${rem(5.5)} ${rem(12)}`,
+                                overflowY: "auto",
+                            }}
+                        >
+                            {/* TODO: Replace with actual data when we update the doc */}
+                            <SourceLink link="https://source1.com" index={1} />
+                            <SourceLink link="https://source2.com" index={2} />
+                            <SourceLink link="https://source3.com" index={3} />
+                            <SourceLink link="https://source4.com" index={4} />
+                            <SourceLink link="https://source5.com" index={5} />
+                            <SourceLink link="https://source6.com" index={6} />
+                        </Stack>
+                    </Group>
+                </Stack>
+            </Modal.Body>
+        </Modal>
+    );
+}

--- a/src/components/MRTable.tsx
+++ b/src/components/MRTable.tsx
@@ -44,7 +44,7 @@ export function MRTable({ data }: { data: Company[] }) {
                 accessorKey: "severity",
                 header: "Severity",
                 Cell: ({ renderedCellValue }) => {
-                    return <SeverityChip severity={renderedCellValue as string} isMobile={!!isMobile} />;
+                    return <SeverityChip severity={renderedCellValue as string} />;
                 },
                 filterVariant: "multi-select",
                 sortingFn: (a, b, colId) => {
@@ -58,7 +58,7 @@ export function MRTable({ data }: { data: Company[] }) {
                 header: "Notes",
             },
         ],
-        [isMobile],
+        [],
     );
 
     const table = useMantineReactTable({

--- a/src/components/MRTable.tsx
+++ b/src/components/MRTable.tsx
@@ -1,9 +1,10 @@
 import { useMantineTheme, Box, createTheme, MantineProvider } from "@mantine/core";
-import { useMediaQuery } from "@mantine/hooks";
+import { useDisclosure, useMediaQuery } from "@mantine/hooks";
 import { MRT_ColumnDef, useMantineReactTable, MantineReactTable } from "mantine-react-table";
 import { useState, useEffect, useMemo } from "react";
 import { Company, Severity, SeverityList } from "src/types";
 import { SeverityChip } from "./SeverityChip";
+import { CompanyModal } from "./CompanyModal";
 
 export function MRTable({ data }: { data: Company[] }) {
     const [pagination, setPagination] = useState({
@@ -11,6 +12,9 @@ export function MRTable({ data }: { data: Company[] }) {
         pageSize: 10,
     });
     const [colVisibility, setColVisibility] = useState({});
+    const [modalOpened, { close: closeModal, open: openModal }] = useDisclosure(false);
+    const [company, setCompany] = useState(data[0]);
+
     const theme = useMantineTheme();
     const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.lg})`);
 
@@ -78,13 +82,25 @@ export function MRTable({ data }: { data: Company[] }) {
             },
             columnVisibility: colVisibility,
         },
+        mantineTableBodyRowProps: ({ row }) => ({
+            onClick: () => {
+                setCompany(data[parseInt(row.id)]);
+                openModal();
+            },
+            sx: {
+                cursor: "pointer",
+            },
+        }),
     });
 
     return (
-        <Box style={{ width: "100%", height: "100%" }}>
-            <MantineProvider theme={newTheme}>
-                <MantineReactTable table={table} />
-            </MantineProvider>
-        </Box>
+        <>
+            <CompanyModal company={company} opened={modalOpened} onClose={closeModal} />
+            <Box style={{ width: "100%", height: "100%" }}>
+                <MantineProvider theme={newTheme}>
+                    <MantineReactTable table={table} />
+                </MantineProvider>
+            </Box>
+        </>
     );
 }

--- a/src/components/SeverityChip.tsx
+++ b/src/components/SeverityChip.tsx
@@ -5,20 +5,11 @@ import {
     IconInfoCircle,
     IconTriangleInvertedFilled,
 } from "@tabler/icons-react";
-import { Chip, Popover, Text } from "@mantine/core";
+import { Chip, Text } from "@mantine/core";
 import { ReactNode } from "react";
 
-function TableChip({ text, color, isMobile, icon }: { text: string; color: string; isMobile: boolean; icon: ReactNode }) {
-    return isMobile ? (
-        <Popover>
-            <Popover.Target>
-                <Chip checked color={color} icon={icon} classNames={{ iconWrapper: "iconWrapper" }}>
-                    {" "}
-                </Chip>
-            </Popover.Target>
-            <Popover.Dropdown>{text}</Popover.Dropdown>
-        </Popover>
-    ) : (
+function TableChip({ text, color, icon }: { text: string; color: string; icon: ReactNode }) {
+    return (
         <Chip checked color={color} icon={icon} classNames={{ iconWrapper: "iconWrapper" }}>
             <Text fw={500} pl="0.2rem">
                 {text}
@@ -27,17 +18,17 @@ function TableChip({ text, color, isMobile, icon }: { text: string; color: strin
     );
 }
 
-export function SeverityChip({ severity, isMobile }: { severity: string; isMobile: boolean }) {
+export function SeverityChip({ severity }: { severity: string }) {
     switch (severity) {
         case "No Significant Investment":
-            return <TableChip text={severity} color="green" isMobile={isMobile} icon={<IconCircleCheck />} />;
+            return <TableChip text={severity} color="green" icon={<IconCircleCheck />} />;
         case "Minimal Involvement":
-            return <TableChip text={severity} color="yellow" isMobile={isMobile} icon={<IconInfoCircle />} />;
+            return <TableChip text={severity} color="yellow" icon={<IconInfoCircle />} />;
         case "Moderate":
-            return <TableChip text={severity} color="orange" isMobile={isMobile} icon={<IconAlertTriangleFilled />} />;
+            return <TableChip text={severity} color="orange" icon={<IconAlertTriangleFilled />} />;
         case "Severe":
-            return <TableChip text={severity} color="red" isMobile={isMobile} icon={<IconTriangleInvertedFilled />} />;
+            return <TableChip text={severity} color="red" icon={<IconTriangleInvertedFilled />} />;
         default:
-            return <TableChip text={severity} color="grey" isMobile={isMobile} icon={<IconHelpHexagonFilled />} />;
+            return <TableChip text={severity} color="grey" icon={<IconHelpHexagonFilled />} />;
     }
 }


### PR DESCRIPTION
Quick example of what an expanded company modal might look like. Behavior occurs on row click in the CFG table. Does not pull in actual data for sources section yet, waiting on addition to actual CFG.

Outstanding questions:
- What other data should we put in this modal?
  - Probably at least a box near the top for "Reason"?
  - Current impl does not allow embedding links, ie we can't link on the [1] marker in the notes part. I'm using the `<textarea>` tag which is the only way I know of that will (reasonably easily) support line breaks in plaintext. Assuming there isn't another method, which feature is more useful: inline links or line breaks?
- Mobile issues:
  - Previously clicking on a severity icon would show a tooltip with the name (which is hidden on mobile, we just show the icon), currently doing so shows the tooltip and then quickly puts the modal on top of it. Probably we should just always show the text and remove the tooltip?
  - Should there be a dedicated button to close the modal?
  - Should the modal be fullscreen on mobile?
![image](https://github.com/user-attachments/assets/f9a41481-d393-4e89-b59e-33ec9188b128)
![image](https://github.com/user-attachments/assets/d31b433a-5683-459a-948b-479f60ad7142)
