### PR TITLE
Fix Loading Indicator

### DIFF
--- a/src/components/MRTable.tsx
+++ b/src/components/MRTable.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useMemo } from "react";
 import { Company, Severity, SeverityList } from "src/types";
 import { SeverityChip } from "./SeverityChip";
 
-export function MRTable({ data }: { data: Company[] }) {
+export function MRTable({ data, isLoading }: { data: Company[]; isLoading: boolean }) {
     const [pagination, setPagination] = useState({
         pageIndex: 0,
         pageSize: 10,
@@ -77,6 +77,7 @@ export function MRTable({ data }: { data: Company[] }) {
                 pageSize: isNaN(pagination.pageSize) ? 999 : pagination.pageSize,
             },
             columnVisibility: colVisibility,
+            isLoading: isLoading,
         },
     });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,7 @@ const theme = createTheme({
 
 const router = createRouter({
     routeTree,
+    defaultPreload: "intent",
     context: {
         fetchData,
     },

--- a/src/routes/guide/route.tsx
+++ b/src/routes/guide/route.tsx
@@ -1,14 +1,15 @@
 import "./route.css";
-import { Box, Loader, Text } from "@mantine/core";
+import { Box, LoadingOverlay } from "@mantine/core";
 import { createFileRoute, useLoaderData } from "@tanstack/react-router";
 import { MRTable } from "src/components/MRTable";
 
-const CareerFairTable = () => {
+const CareerFairTable = ({ isLoading }: { isLoading?: boolean }) => {
     const companies = useLoaderData({ from: "/guide" });
 
     return (
         <Box
             style={{
+                position: "relative",
                 width: "100%",
                 height: "100%",
                 display: "flex",
@@ -17,20 +18,15 @@ const CareerFairTable = () => {
                 alignItems: "center",
             }}
         >
-            {companies === undefined ? (
-                <>
-                    <Text>Loading...</Text>
-                    <Loader />
-                </>
-            ) : (
-                <MRTable data={companies} />
-            )}
+            <LoadingOverlay visible={!!isLoading} zIndex={1000} overlayProps={{ blur: 1 }} />
+            <MRTable data={companies ?? []} isLoading={!!isLoading} />
         </Box>
     );
 };
 
 export const Route = createFileRoute("/guide")({
     loader: ({ context: { fetchData } }) => fetchData(),
+    pendingComponent: () => <CareerFairTable isLoading />,
     staleTime: 600000, // Invalidate cache after 10 mins
     component: CareerFairTable,
 });


### PR DESCRIPTION
Adds a loading state to the CFG. Also enables intent preloading which basically means the network call gets fired when you hover any internal link to the CFG so that the amount of time you're actually waiting goes down a tiny bit.