### PR TITLE
Sticky Table Header

### DIFF
--- a/src/components/MRTable.tsx
+++ b/src/components/MRTable.tsx
@@ -62,10 +62,12 @@ export function MRTable({ data, isLoading }: { data: Company[]; isLoading: boole
         data,
         enableFacetedValues: true,
         enableFullScreenToggle: false,
+        enableStickyHeader: true,
         initialState: {
             isFullScreen: false,
             showColumnFilters: true,
         },
+        mantineTableContainerProps: { style: { maxHeight: "73vh" } },
         mantinePaginationProps: {
             rowsPerPageOptions: ["10", "20", "50", "All"],
         },
@@ -82,7 +84,7 @@ export function MRTable({ data, isLoading }: { data: Company[]; isLoading: boole
     });
 
     return (
-        <Box style={{ width: "100%", height: "100%" }}>
+        <Box w="100%" p="0 0.5rem 0.5rem 0.5rem">
             <MantineProvider theme={newTheme}>
                 <MantineReactTable table={table} />
             </MantineProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,6 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     width: 99vw - 1;
-    height: 100vh;
 }
 
 a {
@@ -24,7 +23,6 @@ a:hover {
 
 body {
     min-width: 320px;
-    min-height: 100vh;
     margin: 0;
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+import { Stack } from "@mantine/core";
 import "./__root.css";
 
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
@@ -7,10 +8,10 @@ import { TopBar } from "src/components/TopBar";
 
 export const Route = createRootRouteWithContext<{ fetchData: typeof fetchData }>()({
     component: () => (
-        <>
+        <Stack mah="100vh" gap={0}>
             <TopBar />
             <Outlet />
             <TanStackRouterDevtools />
-        </>
+        </Stack>
     ),
 });

--- a/src/routes/guide/route.tsx
+++ b/src/routes/guide/route.tsx
@@ -11,7 +11,6 @@ const CareerFairTable = ({ isLoading }: { isLoading?: boolean }) => {
             style={{
                 position: "relative",
                 width: "100%",
-                height: "100%",
                 display: "flex",
                 justifyContent: "center",
                 flexDirection: "column",


### PR DESCRIPTION
Sets the table height to a fixed value, makes the table header sticky. Might look a little off on different screen heights, specifically tablets, but on my desktop + a few mobile devices I tested it looks good.

Fixed height is a requirement to make table header sticky, which I think is useful when the # of rows per page is greater than 10