### PR TITLE
Update moderate criteria language to be more precise

### DIFF
--- a/src/routes/guide/info.tsx
+++ b/src/routes/guide/info.tsx
@@ -235,8 +235,8 @@ const ModerateText = () => {
                     </List.Item>
                 </List>
                 <List.Item className="bodyText">
-                    Significant revenue from subcontracts under the department of defense, Israeli occupation forces, defense contractors,
-                    the intelligence community (CIA, FBI, Mossad, Shin Bet, Aman), etc
+                    Does significant business with or has significant investments from subcontracts under the department of defense, Israeli
+                    occupation forces, defense contractors, the intelligence community (CIA, FBI, Mossad, Shin Bet, Aman), etc
                 </List.Item>
                 <List.Item className="bodyText">Current or previous material support for apartheid, genocide, or Zionism</List.Item>
                 <List pl="md">


### PR DESCRIPTION
Changes "Significant revenue" to "Significant business with or has significant investments" to reflect that companies do not necessarily need to make money from a deal for it to potentially qualify for severity escalation