### PR TITLE
Tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ All data provided by this site is exclusively the opinion of its individual auth
 -   Discord bot command to force refreshing the server's cache of CFG sheet data
 -   Weekly(?) bot message that tests that the sheet data is up to date and that the submission functionality works correctly
 -   Setup a "Dev" server to facilitate testing API changes on Cloudflare branch preview
-    - Allows other people to help test changes before we go live with them
+    -   Allows other people to help test changes before we go live with them

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "tsc -b && vite build",
         "lint": "eslint .",
         "preview": "vite preview",
-        "pre-commit": "pnpm exec prettier . --write --log-level warn && pnpm exec eslint"
+        "mr:check": "pnpm exec prettier . --write --log-level warn && pnpm exec eslint"
     },
     "dependencies": {
         "@mantine/core": "^7.16.0",

--- a/server/server.js
+++ b/server/server.js
@@ -107,13 +107,13 @@ app.get("/data", cors(corsOptions), async (req, res) => {
                 });
             }
 
-            if (globalFilter) {
+            if (globalFilter)
                 returnData = returnData.filter(({ values }) =>
-                    Object.keys(values).some((columnId) =>
-                        values[COLUMN_DEF.indexOf(columnId)]?.toString()?.toLowerCase()?.includes?.(globalFilter.toLowerCase()),
+                    Object.keys(values).some((_, idx) =>
+                        values[idx]?.formattedValue?.toLowerCase()?.includes?.(globalFilter.toLowerCase()),
                     ),
                 );
-            }
+            
 
             const parsedSorting = JSON.parse(sorting ?? "{}");
             if (parsedSorting?.length) {

--- a/server/server.js
+++ b/server/server.js
@@ -99,7 +99,7 @@ app.get("/data", cors(corsOptions), async (req, res) => {
                     } else if (columnId?.toLowerCase() == "tags") {
                         returnData = returnData.filter(({ values }) => {
                             const rowValue = values[COLUMN_DEF.indexOf(columnId)].formattedValue?.toLowerCase();
-                            return filterValue.map((f) => f.toLowerCase()).every((f) => rowValue.includes(f));
+                            return filterValue.map((f) => f.toLowerCase()).some((f) => rowValue.includes(f));
                         });
                     } else {
                         returnData = returnData.filter(({ values }) => {

--- a/src/components/CompanyModal.tsx
+++ b/src/components/CompanyModal.tsx
@@ -1,7 +1,8 @@
-import { Badge, Divider, Group, Modal, rem, Stack, Text, Title, useMantineTheme } from "@mantine/core";
+import { ActionIcon, Badge, Divider, Group, Modal, rem, Stack, Text, Title, useMantineTheme } from "@mantine/core";
 import { SeverityChip } from "./SeverityChip";
 import { Company } from "src/shared/types";
 import { ReactNode } from "react";
+import { IconX } from "@tabler/icons-react";
 
 export type CompanyModalProps = {
     opened: boolean;
@@ -41,15 +42,19 @@ export function CompanyModal({ opened, onClose, company }: CompanyModalProps) {
             centered
         >
             <Modal.Title>
-                <Group
-                    style={{ backgroundColor: "var(--mantine-color-green-0)", overflow: "auto" }}
-                    h="min-content"
-                    w="100%"
-                    p="md"
-                    justify="space-around"
-                >
-                    <Title order={3}>{company.name}</Title>
-                    <SeverityChip severity={company.severity} />
+                <Group p="md" style={{ backgroundColor: "var(--mantine-color-green-0)" }} h="min-content" w="100%" wrap="nowrap">
+                    <Group
+                        h="min-content"
+                        w="100%"
+                        justify="space-around"
+                        style={{ backgroundColor: "var(--mantine-color-green-0)", overflowX: "visible", overflowY: "clip", flexGrow: 10 }}
+                    >
+                        <Title order={3}>{company.name}</Title>
+                        <SeverityChip severity={company.severity} />
+                    </Group>
+                    <ActionIcon color="var(--mantine-color-text)" variant="transparent" onClick={onClose} style={{ flexShrink: 10 }}>
+                        <IconX />
+                    </ActionIcon>
                 </Group>
                 <Divider mx="md" color="var(--mantine-color-green-8)" />
             </Modal.Title>

--- a/src/components/CompanyModal.tsx
+++ b/src/components/CompanyModal.tsx
@@ -1,4 +1,4 @@
-import { Divider, Group, Modal, rem, Stack, Text, Title } from "@mantine/core";
+import { Badge, Divider, Group, Modal, rem, Stack, Text, Title, useMantineTheme } from "@mantine/core";
 import { SeverityChip } from "./SeverityChip";
 import { Company } from "src/shared/types";
 import { ReactNode } from "react";
@@ -11,7 +11,7 @@ export type CompanyModalProps = {
 
 const TextContainer = ({ children }: { children: ReactNode }) => {
     return (
-        <Stack
+        <Group
             flex={10}
             maw="75%"
             mah={rem(200)}
@@ -24,11 +24,13 @@ const TextContainer = ({ children }: { children: ReactNode }) => {
             }}
         >
             {children}
-        </Stack>
+        </Group>
     );
 };
 
 export function CompanyModal({ opened, onClose, company }: CompanyModalProps) {
+    const theme = useMantineTheme();
+
     return (
         <Modal
             opened={opened}
@@ -71,6 +73,18 @@ export function CompanyModal({ opened, onClose, company }: CompanyModalProps) {
                             {/* TODO: Define consistent format for sources
                             & write parser to utilize SourceLinks */}
                             {company.sources.length > 0 ? company.sources.component : "No available sources"}
+                        </TextContainer>
+                    </Group>
+                    <Group w="100%" justify="space-between">
+                        <Title order={4}>Tags:</Title>
+                        <TextContainer>
+                            {company.tags.length == 0
+                                ? "None"
+                                : company.tags.map((tag) => (
+                                      <Badge color={theme.colors.green[0]} key={tag}>
+                                          {tag}
+                                      </Badge>
+                                  ))}
                         </TextContainer>
                     </Group>
                 </Stack>

--- a/src/components/SeverityChip.tsx
+++ b/src/components/SeverityChip.tsx
@@ -39,7 +39,7 @@ export const SeverityChip = ({ severity, hideText }: { severity: string; hideTex
         case "Moderate":
             return <TableChip text={severity} color="orange" icon={<IconAlertTriangleFilled />} hideText={hideText} />;
         case "Severe":
-            return <TableChip text={severity} color="red" icon={<IconTriangleInvertedFilled />} hideText={hideText} />;
+            return <TableChip text={severity} color="#d8070b" icon={<IconTriangleInvertedFilled />} hideText={hideText} />;
         default:
             return <TableChip text={severity} color="grey" icon={<IconHelpHexagonFilled />} hideText={hideText} />;
     }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -70,11 +70,11 @@ export const TopBar = () => {
                     <TextDropdown
                         label="Guide"
                         items={[
-                            <Link key="/guide/" className="topBar" to="/guide">
-                                Data
-                            </Link>,
                             <Link key="/guide/info" className="topBar" to="/guide/info">
                                 Info
+                            </Link>,
+                            <Link key="/guide/" className="topBar" to="/guide">
+                                Data
                             </Link>,
                         ]}
                     />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -70,7 +70,7 @@ export const TopBar = () => {
                     <TextDropdown
                         label="Guide"
                         items={[
-                            <Link key="/guide/" className="topBar" to="/guide/data">
+                            <Link key="/guide/" className="topBar" to="/guide">
                                 Data
                             </Link>,
                             <Link key="/guide/info" className="topBar" to="/guide/info">

--- a/src/main.module.css
+++ b/src/main.module.css
@@ -1,0 +1,10 @@
+.focusClass{
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--mantine-color-green-8);
+    outline-offset: 0;
+  }
+}

--- a/src/main.module.css
+++ b/src/main.module.css
@@ -1,10 +1,10 @@
-.focusClass{
-  &:focus {
-    outline: none;
-  }
+.focusClass {
+    &:focus {
+        outline: none;
+    }
 
-  &:focus-visible {
-    outline: 2px solid var(--mantine-color-green-8);
-    outline-offset: 0;
-  }
+    &:focus-visible {
+        outline: 2px solid var(--mantine-color-green-8);
+        outline-offset: 0;
+    }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,20 +31,26 @@ declare module "@tanstack/react-router" {
     }
 }
 
-export const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            staleTime: 600_000, // 10 mins
+        },
+    },
+});
 
 const rootElement = document.getElementById("root")!;
 if (!rootElement.innerHTML) {
     const root = createRoot(rootElement);
     root.render(
         <StrictMode>
-            <MantineProvider theme={theme}>
-                <ModalsProvider>
-                    <QueryClientProvider client={queryClient}>
+            <QueryClientProvider client={queryClient}>
+                <MantineProvider theme={theme}>
+                    <ModalsProvider>
                         <RouterProvider router={router} />
-                    </QueryClientProvider>
-                </ModalsProvider>
-            </MantineProvider>
+                    </ModalsProvider>
+                </MantineProvider>
+            </QueryClientProvider>
         </StrictMode>,
     );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import classes from "./main.module.css";
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 import "mantine-react-table/styles.css";
@@ -16,6 +17,7 @@ const theme = createTheme({
     colors: {
         green: ["#E1F4E2", "#C3E9C5", "#A6DEA8", "#88D38A", "#6AC86D", "#4CBD50", "#3DA440", "#328634", "#225923", "#163B17"],
     },
+    focusClassName: classes.focusClass,
 });
 
 const router = createRouter({

--- a/src/routes/about/route.tsx
+++ b/src/routes/about/route.tsx
@@ -70,7 +70,7 @@ const AboutOurGuideText = () => {
                 In preparation for RIT's Fall 2024 University-Wide Career Fair, and in the wake of rapidly declining conditions for
                 Palestinian civilians in Gaza who continue to face military bombardment, SJP@RIT volunteers have performed systematic
                 research and analysis for all employers scheduled to appear at the event. This research is outlined and summarized in the{" "}
-                <Link to="/guide/data" className="bodyLink">
+                <Link to="/guide" className="bodyLink">
                     Guide
                 </Link>{" "}
                 section of this website.

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -26,7 +26,6 @@ const ContactPage = () => {
     });
 
     const onSubmit = (data: ContributionsFormData) => {
-        console.log("onsubmit");
         fetch(`${import.meta.env.VITE_BASE_URL}/contact`, {
             method: "POST",
             body: JSON.stringify({ from: data.contact, message: data.message }),

--- a/src/routes/guide/data.tsx
+++ b/src/routes/guide/data.tsx
@@ -272,12 +272,6 @@ const CareerFairTable = () => {
                 enableSorting: false,
                 grow: true,
             },
-            {
-                accessorKey: "tags",
-                header: "Tags",
-                enableSorting: false,
-                Cell: ({ renderedCellValue }) => (renderedCellValue as string[]).join(", "),
-            },
         ],
         [isMobile],
     );

--- a/src/routes/guide/index.tsx
+++ b/src/routes/guide/index.tsx
@@ -2,6 +2,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/guide/")({
     beforeLoad: () => {
-        throw redirect({ to: "/guide/data" });
+        throw redirect({ to: "/guide/data", search: { filters: [{ id: "tags", value: ["RIT Spring 2025 Career Fair"] }] } });
     },
 });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -29,7 +29,10 @@ function LandingPage() {
 
     return (
         <Box style={{ display: "flex", flexDirection: "column", margin: "0.5rem" }}>
-            <Group style={{ textAlign: "right", paddingTop: "5rem", display: "flex", flexDirection: "column", alignItems: "flex-end" }}>
+            <Group
+                mx="xs"
+                style={{ textAlign: "right", paddingTop: "5rem", display: "flex", flexDirection: "column", alignItems: "flex-end" }}
+            >
                 <Title
                     order={1}
                     style={{

--- a/src/shared/api.tsx
+++ b/src/shared/api.tsx
@@ -45,12 +45,20 @@ export function parseSheetData(data?: Cell[]) {
                     reason: raw.values[3].formattedValue,
                     sources: parseLink(raw.values[4]),
                     notes: raw.values[5].formattedValue,
+                    tags: raw.values[6].formattedValue.split(", "),
                 }) as Company,
         ) ?? []
     );
 }
 
-export const infiniteQueryFn = async ({
+export async function fetchTagsQueryFn(signal: AbortSignal) {
+    const url = new URL("/tags", import.meta.env.VITE_BASE_URL);
+    const res = await fetch(url.href, { signal });
+    const json = await res.json();
+    return json as { tags: string[] };
+}
+
+export async function infiniteQueryFn({
     pageParam = 0,
     signal,
     columnFilters,
@@ -62,7 +70,7 @@ export const infiniteQueryFn = async ({
     columnFilters: MRT_ColumnFiltersState;
     globalFilter?: string;
     sorting: MRT_SortingState;
-}) => {
+}) {
     const url = new URL("/data", import.meta.env.VITE_BASE_URL);
     url.searchParams.set("offset", `${pageParam * paginatedChunkSize}`);
     url.searchParams.set("limit", `${paginatedChunkSize}`);
@@ -73,4 +81,4 @@ export const infiniteQueryFn = async ({
     const response = await fetch(url.href, { signal });
     const json = await response.json();
     return json as ApiResponse;
-};
+}

--- a/src/shared/fns.ts
+++ b/src/shared/fns.ts
@@ -1,0 +1,4 @@
+export function capitalize(input: string) {
+    if (input.length == 0) return input;
+    return String(input).charAt(0).toUpperCase() + String(input).slice(1);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,7 @@ export type Company = {
     reason?: string;
     sources: { length: number; component: ReactNode };
     notes?: string;
+    tags: string[];
 };
 export type Cell = {
     values: {


### PR DESCRIPTION
Changes in this PR:
- Adds "tag" support
  - Currently tags are just for membership in a career fair, but this can be expanded later
  - data is pulled from the "tags" column on the doc
  - `/tags` endpoint on API lists all tags. Data is re-computed on each refresh of sheet data
- Filtering re-work
  - no longer uses built in filtering options 😢 
  - Modal format makes mobile experience better hopefully
  - Applied filters display as chips adjacent to the filter button
    - Can be individually cleared by clicking on the x icon
  - Adds a global filter called keyword which will match any text in any column (including tags)
- Applied a redirect to links on the site to auto-apply an RIT Spring 2025 Career Fair filter when navigating to the guide
- 